### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,5 +11,5 @@ TODO\.md
 ^\.drone\.yml$
 ^Jenkinsfile$
 ^\.lintr$
-^staged_dependencies.yaml$
+^staged_dependencies\.yaml$
 ^LICENSE\.md$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\\.yaml$.

Dot was not escaped