### PR TITLE
remove hermes downstream dep

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -5,3 +5,4 @@ upstream_repos:
   insightsengineering/test.nest:
     repo: insightsengineering/test.nest
     host: https://github.com
+downstream_repos:


### PR DESCRIPTION
 ggplot2.utils claims hermes is a downstream dependency https://github.com/insightsengineering/ggplot2.utils/blob/main/staged_dependencies.yaml but it doesn't seem to be anymore https://github.com/insightsengineering/hermes/blob/main/DESCRIPTION

this is fixed here