### PR TITLE
devops: removed `test.nest` dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,12 +3,12 @@ Package: ggplot2.utils
 Title: ggplot2 utilities
 Version: 0.1.3.9006
 Date: 2021-10-13
-Authors@R: 
+Authors@R:
     person("NEST", , , "nestcicd@roche.com", role = c("aut", "cre"))
 Description: Utilities, in particular geoms and stats, for use with
     ggplot2.
 License: Apache License 2.0 | file LICENSE
-Depends: 
+Depends:
     ggplot2 (>= 3.3.0),
     R (>= 3.6)
 Imports:
@@ -17,7 +17,6 @@ Imports:
     ggpp
 Suggests:
     dplyr,
-    test.nest (>= 0.2.11),
     testthat (>= 2.0),
     tibble
 Encoding: UTF-8

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -2,7 +2,4 @@ current_repo:
   repo: insightsengineering/ggplot2.utils
   host: https://github.com
 upstream_repos:
-  insightsengineering/test.nest:
-    repo: insightsengineering/test.nest
-    host: https://github.com
 downstream_repos:

--- a/tests/testthat/test-nest.R
+++ b/tests/testthat/test-nest.R
@@ -1,3 +1,0 @@
-library(test.nest)
-
-test_all(exclude_from_tests = list("test_importfrom"))


### PR DESCRIPTION
Related to insightsengineering/coredev-tasks#70
